### PR TITLE
Use Earth Radios from WGS84

### DIFF
--- a/src/main/java/com/thegeekyasian/geoassist/kdtree/KDTree.java
+++ b/src/main/java/com/thegeekyasian/geoassist/kdtree/KDTree.java
@@ -242,7 +242,7 @@ public class KDTree<T, O> {
 		double lat2 = point2.getLatitude();
 		double lon2 = point2.getLongitude();
 
-		double R = 6371; // radius of Earth in kilometers
+		double R = 6378.137; // radius of Earth in kilometers WGS84
 		double dLat = Math.toRadians(lat2 - lat1);
 		double dLon = Math.toRadians(lon2 - lon1);
 		lat1 = Math.toRadians(lat1);


### PR DESCRIPTION
WGS84 World Geodetic System 1984, used in GPS 
https://en.wikipedia.org/wiki/World_Geodetic_System#WGS84

soon: EPSG:10176
Used for products from the International GNSS Service (IGS) from 2022-11-27. Replaces IGb14 (code 9378). For most practical purposes IGS20 is equivalent to ITRF2020.